### PR TITLE
Update _valueChanged function to prevent TypeError

### DIFF
--- a/src/editor.ts
+++ b/src/editor.ts
@@ -116,7 +116,7 @@ export class BoilerplateCardEditor extends LitElement implements LovelaceCardEdi
     }
 
     // You can restrict on domain type
-    const entities = Object.keys(this.hass.states).filter(eid => eid.substr(0, eid.indexOf('.')) === 'sun');
+    const entities = Object.keys(this.hass.states).filter((eid) => eid.substr(0, eid.indexOf('.')) === 'sun');
 
     return html`
       <div class="card-config">
@@ -136,10 +136,8 @@ export class BoilerplateCardEditor extends LitElement implements LovelaceCardEdi
                   .configValue=${'entity'}
                 >
                   <paper-listbox slot="dropdown-content" .selected=${entities.indexOf(this._entity)}>
-                    ${entities.map(entity => {
-                      return html`
-                        <paper-item>${entity}</paper-item>
-                      `;
+                    ${entities.map((entity) => {
+                      return html` <paper-item>${entity}</paper-item> `;
                     })}
                   </paper-listbox>
                 </paper-dropdown-menu>
@@ -264,17 +262,19 @@ export class BoilerplateCardEditor extends LitElement implements LovelaceCardEdi
     if (this[`_${target.configValue}`] === target.value) {
       return;
     }
+    let config = Object.assign({}, this._config);
     if (target.configValue) {
       if (target.value === '') {
-        delete this._config[target.configValue];
+        delete config[target.configValue];
       } else {
-        this._config = {
-          ...this._config,
+        config = {
+          ...config,
           [target.configValue]: target.checked !== undefined ? target.checked : target.value,
         };
       }
     }
-    fireEvent(this, 'config-changed', { config: this._config });
+
+    fireEvent(this, 'config-changed', { config: config });
   }
 
   static get styles(): CSSResult {


### PR DESCRIPTION
First, I apologize for my linter updating more than just the small snippet.

If merged, this pull request will prevent a TypeError that occurs when trying to call `delete this._config` for a value in the config.

The issue occurs because `this._config` is read-only. The quick-fix is to deep-copy the config to a new object using `Object.assign({}, this._config)`.

If other solutions are preferred, I am happy to update the pull request.