### PR TITLE
Add warning and error methods. Refactor types

### DIFF
--- a/src/boilerplate-card.ts
+++ b/src/boilerplate-card.ts
@@ -7,6 +7,7 @@ import {
   handleAction,
   LovelaceCardEditor,
   getLovelace,
+  LovelaceCard,
 } from 'custom-card-helpers';
 
 import './editor';
@@ -43,8 +44,8 @@ export class BoilerplateCard extends LitElement {
   }
 
   // TODO Add any properities that should cause your element to re-render here
-  @property() public hass?: HomeAssistant;
-  @property() private _config?: BoilerplateCardConfig;
+  @property() public hass!: HomeAssistant;
+  @property() private _config!: BoilerplateCardConfig;
 
   public setConfig(config: BoilerplateCardConfig): void {
     // TODO Check for required fields and that they are of the proper format
@@ -67,17 +68,9 @@ export class BoilerplateCard extends LitElement {
   }
 
   protected render(): TemplateResult | void {
-    if (!this._config || !this.hass) {
-      return html``;
-    }
-
     // TODO Check for stateObj or other necessary things and render a warning if missing
     if (this._config.show_warning) {
-      return html`
-        <ha-card>
-          <div class="warning">${localize('common.show_warning')}</div>
-        </ha-card>
-      `;
+      return this.showWarning(localize('common.show_warning'));
     }
 
     return html`
@@ -98,6 +91,25 @@ export class BoilerplateCard extends LitElement {
     if (this.hass && this._config && ev.detail.action) {
       handleAction(this, this.hass, this._config, ev.detail.action);
     }
+  }
+
+  private showWarning(warning: string): TemplateResult {
+    return html`
+      <hui-warning>${warning}</hui-warning>
+    `;
+  }
+
+  private showError(error: string): TemplateResult {
+    const errorCard = document.createElement('hui-error-card') as LovelaceCard;
+    errorCard.setConfig({
+      type: 'error',
+      error,
+      origConfig: this._config,
+    });
+
+    return html`
+      ${errorCard}
+    `;
   }
 
   static get styles(): CSSResult {

--- a/src/boilerplate-card.ts
+++ b/src/boilerplate-card.ts
@@ -113,13 +113,6 @@ export class BoilerplateCard extends LitElement {
   }
 
   static get styles(): CSSResult {
-    return css`
-      .warning {
-        display: block;
-        color: black;
-        background-color: #fce588;
-        padding: 8px;
-      }
-    `;
+    return css``;
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,7 @@
-import { ActionConfig } from 'custom-card-helpers';
+import { ActionConfig, LovelaceCardConfig } from 'custom-card-helpers';
 
 // TODO Add your configuration elements here for type-checking
-export interface BoilerplateCardConfig {
+export interface BoilerplateCardConfig extends LovelaceCardConfig {
   type: string;
   name?: string;
   show_warning?: boolean;


### PR DESCRIPTION
Hi 👋 

First, thanks for the awesome template! This has really helped me a lot to get onboarded with card development quickly!

I'm suggesting some changes that I'm using in the cards I'm working on:

### non-null assertions
My understanding is that `hass` and `_config` will realistically never be undefined. The optional type is just a side effect of typescript + lit-element.

This adds a `!` to help clean things up. After that you don't have to do checks in the `render` and you don't have to use optional chaining / nullish coalescing everywhere.

### `showWarning` and `showError`
This took me some time to figure out initially, so I thought it may be nice to include in the template.

`showWarning` and `showError` render native lovelace warning and error cards, which is useful if you want to mimic native behavior.

I figured if someone wants to use this, they won't need to figure it out on their own. And if they want to implement custom error/warning states, they can always delete the defaults and build their own.

### `BoilerplateCardConfig extends LovelaceCardConfig`

Not that it really matters, but it's a more specific type and it's useful to be able to go to the base definition if you want to.
