### PR TITLE
Extend tag element definition to avoid some cast

### DIFF
--- a/src/boilerplate-card.ts
+++ b/src/boilerplate-card.ts
@@ -7,7 +7,6 @@ import {
   handleAction,
   LovelaceCardEditor,
   getLovelace,
-  LovelaceCard,
 } from 'custom-card-helpers';
 
 import './editor';
@@ -36,7 +35,7 @@ console.info(
 @customElement('boilerplate-card')
 export class BoilerplateCard extends LitElement {
   public static async getConfigElement(): Promise<LovelaceCardEditor> {
-    return document.createElement('boilerplate-card-editor') as LovelaceCardEditor;
+    return document.createElement('boilerplate-card-editor');
   }
 
   public static getStubConfig(): object {
@@ -100,7 +99,7 @@ export class BoilerplateCard extends LitElement {
   }
 
   private showError(error: string): TemplateResult {
-    const errorCard = document.createElement('hui-error-card') as LovelaceCard;
+    const errorCard = document.createElement('hui-error-card');
     errorCard.setConfig({
       type: 'error',
       error,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,11 @@
-import { ActionConfig, LovelaceCardConfig } from 'custom-card-helpers';
+import { ActionConfig, LovelaceCard, LovelaceCardConfig, LovelaceCardEditor } from 'custom-card-helpers';
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'boilerplate-card-editor': LovelaceCardEditor;
+    'hui-error-card': LovelaceCard;
+  }
+}
 
 // TODO Add your configuration elements here for type-checking
 export interface BoilerplateCardConfig extends LovelaceCardConfig {


### PR DESCRIPTION
Tiny fix to avoid some type cast ;)

Also one question related to this part

```js
export class BoilerplateCard extends LitElement {
  public static async getConfigElement(): Promise<LovelaceCardEditor> {
    return document.createElement('boilerplate-card-editor');
  }
```

is there a reason to make this function async? `createElement` is sync. This will defer the result to the end of the event loop, hitting micro task queue.