### PR TITLE
Add entity picker

### DIFF
--- a/src/const.ts
+++ b/src/const.ts
@@ -1,1 +1,1 @@
-export const CARD_VERSION = '1.4.1';
+export const CARD_VERSION = '1.4.1b';

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -45,6 +45,10 @@ export class BoilerplateCardEditor extends ScopedRegistryHost(LitElement) implem
     return this._config?.name || '';
   }
 
+  get _picker_entity(): string {
+    return this._config?.picker_entity || '';
+  }
+
   get _entity(): string {
     return this._config?.entity || '';
   }
@@ -57,15 +61,46 @@ export class BoilerplateCardEditor extends ScopedRegistryHost(LitElement) implem
     return this._config?.show_error || false;
   }
 
+  protected async firstUpdated(): Promise<void> {
+    this.loadEntityPicker();
+  }
+
+  async loadEntityPicker(): Promise<void> {
+    // Get the local customElement registry
+    const registry = (this.shadowRoot as any)?.customElements;
+    if (!registry) return;
+
+    // Check if the element we want is already defined in the local scope
+    if (registry.get("ha-entity-picker")) return;
+
+    // Load in ha-entity-picker
+    // This part will differ for every element you want
+    const ch = await (window as any).loadCardHelpers();
+    const c = await ch.createCardElement({ type: "entities", entities: [] });
+    await c.constructor.getConfigElement();
+
+    // Since ha-elements are not using scopedRegistry we can get a reference to
+    // the newly loaded element from the global customElement registry...
+    const haEntityPicker = window.customElements.get("ha-entity-picker");
+
+    // ... and use that reference to register the same element in the local registry
+    registry.define("ha-entity-picker", haEntityPicker);
+  }
+
   protected render(): TemplateResult | void {
     if (!this.hass || !this._helpers) {
       return html``;
     }
 
+    console.info('render');
+
     // You can restrict on domain type
     const entities = Object.keys(this.hass.states);
 
     return html`
+      <ha-entity-picker .hass=${this.hass} .configValue=${'picker_entity'} .value=${this._picker_entity} name="PickerEntity"
+        label="Entity Current Conditions (Required)" allow-custom-entity @value-changed=${this._valueChangedPicker}>
+      </ha-entity-picker>
       <mwc-select
         naturalMenuWidth
         fixedMenuPosition
@@ -83,21 +118,21 @@ export class BoilerplateCardEditor extends ScopedRegistryHost(LitElement) implem
         label="Name (Optional)"
         .value=${this._name}
         .configValue=${'name'}
-        @input=${this._valueChanged}
-      ></mwc-textfield>
+        @input=${this._valueChanged}>
+      </mwc-textfield>
       <mwc-formfield .label=${`Toggle warning ${this._show_warning ? 'off' : 'on'}`}>
         <mwc-switch
           .checked=${this._show_warning !== false}
           .configValue=${'show_warning'}
-          @change=${this._valueChanged}
-        ></mwc-switch>
+          @change=${this._valueChanged}>
+        </mwc-switch>
       </mwc-formfield>
       <mwc-formfield .label=${`Toggle error ${this._show_error ? 'off' : 'on'}`}>
         <mwc-switch
           .checked=${this._show_error !== false}
           .configValue=${'show_error'}
-          @change=${this._valueChanged}
-        ></mwc-switch>
+          @change=${this._valueChanged}>
+        </mwc-switch>
       </mwc-formfield>
     `;
   }
@@ -111,6 +146,23 @@ export class BoilerplateCardEditor extends ScopedRegistryHost(LitElement) implem
 
   private async loadCardHelpers(): Promise<void> {
     this._helpers = await (window as any).loadCardHelpers();
+  }
+
+  private _valueChangedPicker(ev): void {
+    if (!this._config || !this.hass) {
+      return;
+    }
+    const target = ev.target;
+    if (this[`_${target.configValue}`] === target.value) {
+      return;
+    }
+    if (target.configValue) {
+      this._config = {
+        ...this._config,
+        [target.configValue]: target.value,
+      };
+    }
+    fireEvent(this, 'config-changed', { config: this._config });
   }
 
   private _valueChanged(ev): void {

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,7 @@ export interface BoilerplateCardConfig extends LovelaceCardConfig {
   show_error?: boolean;
   test_gui?: boolean;
   entity?: string;
+  picker_entity?: string;
   tap_action?: ActionConfig;
   hold_action?: ActionConfig;
   double_tap_action?: ActionConfig;


### PR DESCRIPTION
This PR adds an entity picker to the boilerplate card and reports errors if a non-existent entity is configured.
Please check that I am doing this the correct way before merging as there may be a better/more correct way to do it.