### PR TITLE
Disable code spliting

### DIFF
--- a/rollup.config.dev.js
+++ b/rollup.config.dev.js
@@ -14,6 +14,7 @@ export default {
   output: {
     dir: './dist',
     format: 'es',
+    inlineDynamicImports: true,
   },
   plugins: [
     resolve(),

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -43,6 +43,7 @@ export default [
     output: {
       dir: 'dist',
       format: 'es',
+      inlineDynamicImports: true,
     },
     plugins: [...plugins],
   },


### PR DESCRIPTION
The current version of boilerplate card insteed of generating one file `boilerplate-card.js` upon running `npm run build` actually generates three:

![image](https://user-images.githubusercontent.com/23432278/174662065-5ff697bc-98e7-4a60-b78a-9743de173762.png)

After this PR it's back to one:

![image](https://user-images.githubusercontent.com/23432278/174662034-031011d0-6d45-4ecc-920c-ba3c17d6cf34.png)
