### PR TITLE
Requirements: node version => 12.x, npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ Click the "Use this template" button on the main page and clone the new reposito
 
 ### Step 2
 
-Install necessary modules (verified to work in node 8.x)
-`yarn install` or `npm install`
+Install necessary modules (verified to work in node lts/erbium v12.22.12)
+`npm install`
 
 ### Step 3
 
@@ -92,19 +92,6 @@ If you need a fresh test instance you can install a fresh Home Assistant instanc
 1. Run the command `container start`.
 2. Home Assistant will install and will eventually be running on port `9123`
 
-## [Troubleshooting](https://github.com/thomasloven/hass-config/wiki/Lovelace-Plugins)
-
-NB This will not work with node 9.x if you see the following errors try installing node 8.10.0
-
-```yarn install
-yarn install v1.3.2
-[1/4] 🔍  Resolving packages...
-warning rollup-plugin-commonjs@10.1.0: This package has been deprecated and is no longer maintained. Please use @rollup/plugin-commonjs.
-[2/4] 🚚  Fetching packages...
-error @typescript-eslint/eslint-plugin@2.6.0: The engine "node" is incompatible with this module. Expected version "^8.10.0 || ^10.13.0 || >=11.10.1".
-error Found incompatible module
-info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
-```
 
 [commits-shield]: https://img.shields.io/github/commit-activity/y/custom-cards/boilerplate-card.svg?style=for-the-badge
 [commits]: https://github.com/custom-cards/boilerplate-card/commits/master


### PR DESCRIPTION
1.) At least one node module depends upon 12.x:

`Unsupported engine for eslint-plugin-prettier@4.2.1: wanted: {"node":">=12.0.0"}`

I makes sense to use LTS for the older versions. So I tried `lts/erbium -> v12.22.12`.

2.) Remove troubleshooting for older versions.

3.) Remove `yarn`. `npm` has been improved meanwhile. Keep the README simple.